### PR TITLE
Small fix for torrent.py

### DIFF
--- a/debug/torrent.py
+++ b/debug/torrent.py
@@ -34,7 +34,8 @@ class Torrent(object):
             self.created_by = ''
         if b'creation date' in self._torrent_dict:
             creation_date_timestamp = self._torrent_dict[b'creation date']
-            self.creation_date = dt.fromtimestamp(creation_date_timestamp)
+            time_as_float = time.mktime(creation_date_timestamp.timetuple())
+            self.creation_date = time_as_float
         else:
             self.creation_date = dt.fromtimestamp(0)
         if b'encoding' in self._torrent_dict:


### PR DESCRIPTION
Typing issue with the timestamp for creation date was uncovered after I changed the creation date key to the proper string in `db.get_torrent()`. Had to cast timestamp to float type to fix the issue, as mentioned in the group's #implementation Slack channel.